### PR TITLE
Port mktoc to Python 3

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,8 +51,8 @@ source_suffix = '.rst'
 master_doc = 'contents'
 
 # General information about the project.
-project = u'Mktoc'
-copyright = u'2011, ' + __author__
+project = 'Mktoc'
+copyright = '2011, ' + __author__
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -192,8 +192,8 @@ htmlhelp_basename = 'Mktocdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('contents', 'Mktoc.tex', u'Mktoc Documentation',
-   u'Patrick C. McGinty', 'manual'),
+  ('contents', 'Mktoc.tex', 'Mktoc Documentation',
+   'Patrick C. McGinty', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -225,8 +225,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('contents', 'mktoc', u'Mktoc Documentation',
-     [u'Patrick C. McGinty'], 1)
+    ('contents', 'mktoc', 'Mktoc Documentation',
+     ['Patrick C. McGinty'], 1)
 ]
 
 # autodoc settings

--- a/mktoc/cmdline.py
+++ b/mktoc/cmdline.py
@@ -61,7 +61,7 @@ class CommandLine(object):
          self._error_msg_multi_files(e)
       except FileNotFoundError as e:
          self._error_msg_no_file(e)
-      except MkTocError, e:
+      except MkTocError as e:
          self._error_msg(e)
 
    def _run(self,argv):
@@ -97,7 +97,7 @@ class CommandLine(object):
       toc = cd_obj.getToc()
       # open TOC file
       if opt.toc_file:
-         fh_out = self._open_file( opt.toc_file,'wb')
+         fh_out = self._open_file( opt.toc_file,'wb','utf-8' )
          fh_out.write( self._banner_msg())
          for l in toc:
             fh_out.write("%s\n" % l)
@@ -105,8 +105,7 @@ class CommandLine(object):
          fh_out = sys.stdout
          fh_out.write( self._banner_msg())
          for l in toc:
-            # assume utf-8 encoding to sysout
-            fh_out.write(unicode("%s\n" % l).encode('utf-8'))
+            fh_out.write(str("%s\n" % l))
       fh_out.close()
 
       if cd_obj.disc.is_multisession:
@@ -114,7 +113,7 @@ class CommandLine(object):
          # frame length minus 2 frames. I'm not actually sure why 2 frames must
          # be subtracked, but it was verify to be correct. If your system/drive
          # behaves differntly, please file a bug report.
-         print >> sys.stderr, textwrap.dedent("""
+         print(textwrap.dedent("""
          #########################################################
          # Multi-Session TOC Mode
          #########################################################
@@ -125,7 +124,7 @@ class CommandLine(object):
             cdrecord --tsize=%ds /dev/zero
 
          #########################################################
-         """ % (cd_obj.last_index.len_.frames-2))    # see note for '-2'
+         """ % (cd_obj.last_index.len_.frames-2)), file=sys.stderr)    # see note for '-2'
 
    @staticmethod
    def _open_file(name,mode='rb',encoding=None):
@@ -141,7 +140,7 @@ class CommandLine(object):
                encoding = d.result['encoding']
          return codecs.open(name, mode, encoding=encoding)
       except:
-         print >> sys.stderr, sys.exc_value
+         print(sys.exc_info()[1], file=sys.stderr)
          exit(-1)
 
    def _check_multisession_opt(self, cd, opt):
@@ -153,7 +152,7 @@ class CommandLine(object):
          cd.disc.is_multisession = False
       elif not opt.multisession:
          # multisesssion option must be set to prevent usage error
-         print >> sys.stderr, textwrap.dedent("""
+         print(textwrap.dedent("""
             WARNING! - Detected multi-session track info.
 
             For safety, '%s' option must be specified when creating a TOC
@@ -161,7 +160,7 @@ class CommandLine(object):
 
             If you want to ignore this check, and disable multi-session
             features, use the '%s' argument.""" %
-               (_OPT_MULTI_SESSION,_OPT_IGNORE_MULTI_SESSION))
+               (_OPT_MULTI_SESSION,_OPT_IGNORE_MULTI_SESSION)), file=sys.stderr)
          sys.exit(-1)
 
    def _banner_msg(self):
@@ -280,39 +279,39 @@ class CommandLine(object):
 
    def _error_msg(self, e):
       """Print a default error message to the user."""
-      print >> sys.stderr, textwrap.dedent((u"""
+      print(textwrap.dedent(("""
       ERROR! -- An unrecoverable error has occurred.
 
       If you believe the CUE file is correct, please send the input file to
       <%s>, along with the error message below.
 
       ---> %s
-      """ % (__email__,e)).encode('utf-8'))
+      """ % (__email__,e))), file=sys.stderr)
 
    def _error_msg_multi_files(self, e):
       """Print error when duplicate WAV files are found."""
-      print >> sys.stderr, textwrap.dedent( (u"""
+      print(textwrap.dedent( ("""
       ERROR! -- Could not resolve WAV file:
-         '%s'\n""" % (e.src_file,)).encode('utf-8'))
+         '%s'\n""" % (e.src_file,))), file=sys.stderr)
 
-      print >> sys.stderr, "   Conflicting matches are:"
+      print("   Conflicting matches are:", file=sys.stderr)
       for f in e.found_files:
-         print >> sys.stderr, '      ' + unicode(f).encode('utf-8')
+         print('      ' + str(f), file=sys.stderr)
 
-      print >> sys.stderr, textwrap.dedent( """
+      print(textwrap.dedent( """
       Cdrdao can not correctly write pregaps in TOC files without explicit
       file lengths. If you know what you are doing, you can disable this
-      check with the '%s' option.""" % (_OPT_ALLOW_WAV_FNF,))
+      check with the '%s' option.""" % (_OPT_ALLOW_WAV_FNF,)), file=sys.stderr)
 
    def _error_msg_no_file(self, e):
       """Print a missing WAV file error message to the user."""
-      print >> sys.stderr, textwrap.dedent( (u"""
+      print(textwrap.dedent( ("""
       ERROR! -- Could not find the WAV file:
          '%s'
 
       Cdrdao can not correctly write pregaps in TOC files without explicit
       file lengths. If you know what you are doing, you can disable this
-      check with the '%s' option.""" % (e,_OPT_ALLOW_WAV_FNF,)).encode('utf-8'))
+      check with the '%s' option.""" % (e,_OPT_ALLOW_WAV_FNF,))), file=sys.stderr)
 
 
 def main():

--- a/mktoc/disc.py
+++ b/mktoc/disc.py
@@ -58,16 +58,16 @@ class Disc( object ):
    def __str__(self):
       raise NotImplementedError
 
-   def __unicode__(self):
+   def __str__(self):
       """Return a string of TOC formatted disc information."""
-      out = [u'%s' % self._mode]
-      if self.catalog:   out += [u'CATALOG "%s"' % self.catalog]
-      out += [u'CD_TEXT { LANGUAGE_MAP { 0:EN }\n\tLANGUAGE 0 {']
-      if self.title:     out += [u'\t\tTITLE "%s"' % self.title]
-      if self.performer: out += [u'\t\tPERFORMER "%s"' % self.performer]
-      if self.discid:    out += [u'\t\tDISC_ID "%s"' % self.discid]
-      out += [u'}}']
-      return u'\n'.join(out)
+      out = ['%s' % self._mode]
+      if self.catalog:   out += ['CATALOG "%s"' % self.catalog]
+      out += ['CD_TEXT { LANGUAGE_MAP { 0:EN }\n\tLANGUAGE 0 {']
+      if self.title:     out += ['\t\tTITLE "%s"' % self.title]
+      if self.performer: out += ['\t\tPERFORMER "%s"' % self.performer]
+      if self.discid:    out += ['\t\tDISC_ID "%s"' % self.discid]
+      out += ['}}']
+      return '\n'.join(out)
 
    def set_field(self, name, value):
       """
@@ -174,28 +174,28 @@ class Track( object ):
    def __str__(self):
       raise NotImplementedError
 
-   def __unicode__(self):
+   def __str__(self):
       """Return the TOC formated representation of the :class:`Track`
       object including the :class:`TrackIndex` objects. Data tracks will
       not generate any output."""
       if self.is_data:
          return ''     # do not output to TOC
-      out = [u'\n//Track %d' % self.num]
-      out += [u'TRACK AUDIO']
-      if self.isrc:       out += [u'\tISRC "%s"' % self.isrc]
-      if self.dcp:        out += [u'\tCOPY']
-      if self.four_ch:    out += [u'\tFOUR_CHANNEL_AUDIO']
-      if self.pre:        out += [u'\tPRE_EMPHASIS']
-      out += [u'\tCD_TEXT { LANGUAGE 0 {']
-      if self.title:      out += [u'\t\tTITLE "%s"' % self.title]
-      if self.performer:  out += [u'\t\tPERFORMER "%s"' % self.performer]
-      out += [u'\t}}']
-      if self.pregap:     out += [u'\tPREGAP %s' % self.pregap]
+      out = ['\n//Track %d' % self.num]
+      out += ['TRACK AUDIO']
+      if self.isrc:       out += ['\tISRC "%s"' % self.isrc]
+      if self.dcp:        out += ['\tCOPY']
+      if self.four_ch:    out += ['\tFOUR_CHANNEL_AUDIO']
+      if self.pre:        out += ['\tPRE_EMPHASIS']
+      out += ['\tCD_TEXT { LANGUAGE 0 {']
+      if self.title:      out += ['\t\tTITLE "%s"' % self.title]
+      if self.performer:  out += ['\t\tPERFORMER "%s"' % self.performer]
+      out += ['\t}}']
+      if self.pregap:     out += ['\tPREGAP %s' % self.pregap]
 
       for idx in self.indexes:
-         out.append( unicode(idx) )
+         out.append( str(idx) )
 
-      return u'\n'.join(out)
+      return '\n'.join(out)
 
    def set_field(self, name, value):
       """
@@ -215,7 +215,7 @@ class Track( object ):
       """
       name = name.lower()
       if hasattr(self,name):
-         if isinstance(value,basestring):
+         if isinstance(value,str):
             setattr(self,name,value.strip('"'))
          elif isinstance(value,bool):
             setattr(self,name,value)
@@ -280,7 +280,7 @@ class TrackIndex(object):
    """
 
    #: Enum of valid :class:`TrackIndex` types.
-   PREAUDIO, AUDIO, INDEX, START, DATA = range(5)
+   PREAUDIO, AUDIO, INDEX, START, DATA = list(range(5))
 
    #: Integer set to :const:`PREAUDIO` or :const:`AUDIO` or :const:`INDEX` or
    #: :const:`START`. Indicate the mode of :class:`TrackIndex` object.
@@ -319,28 +319,28 @@ class TrackIndex(object):
 
    def __repr__(self):
       """Return a string used for debug logging."""
-      return ("'%s, %s'" % (self.file_, self.time)).encode('utf-8')
+      return ("'%s, %s'" % (self.file_, self.time))
 
    def __str__(self):
       raise NotImplementedError
 
-   def __unicode__(self):
+   def __str__(self):
       """Return the TOC formated string representation of the
       :class:`TrackIndex` object."""
       out = []
       if self.cmd == self.DATA:
-         return u''     # do not output to TOC
+         return ''     # do not output to TOC
       if self.cmd in [self.AUDIO, self.PREAUDIO]:
-         out += [u'\tAUDIOFILE "%(file_)s" %(time)s %(len_)s' % self.__dict__]
+         out += ['\tAUDIOFILE "%(file_)s" %(time)s %(len_)s' % self.__dict__]
       elif self.cmd == self.INDEX:
-         out += [u'\tINDEX %(time)s' % self.__dict__]
+         out += ['\tINDEX %(time)s' % self.__dict__]
       elif self.cmd == self.START:
-         out += [u'\tSTART %(len_)s' % self.__dict__]
+         out += ['\tSTART %(len_)s' % self.__dict__]
       else: raise Exception
       # add start command for pregap audio
       if self.cmd == self.PREAUDIO:
-         out += [u'\tSTART']
-      return u'\n'.join(out)
+         out += ['\tSTART']
+      return '\n'.join(out)
 
    def _file_len(self,file_):
       """Returns the number of audio samples in the WAV file, *file_*.
@@ -390,14 +390,14 @@ class _TrackTime(object):
                      c. Integer of the total frame length
                      d. :data:`None`, object is initialized to 0 length
       :type arg: str, :class:`tuple`, int, :data:`None`"""
-      if isinstance(arg,basestring):
+      if isinstance(arg,str):
          # extract time from string
          val = [int(x) for x in arg.split(':')]
          self._time = tuple(val)
       elif isinstance(arg,tuple):
          # assume arg is correct format
          self._time = arg
-      elif isinstance(arg,(int,long)):
+      elif isinstance(arg,int):
          # convert frame count to min,sec,frames
          min_,fr = divmod(arg, self._FPM)
          sec,fr = divmod(fr, self._FPS)
@@ -421,11 +421,10 @@ class _TrackTime(object):
 
    def __sub__(self, other):
       """Return result of *self* - *other*."""
-      mn,sc,fr = map(lambda x,y: x-y, self._time, other._time)
+      mn,sc,fr = list(map(lambda x,y: x-y, self._time, other._time))
       if fr<0: sc-=1; fr+=self._FPS
       if sc<0: mn-=1; sc+=self._SPM
-      if mn<0: raise UnderflowError, \
-         'Track time calculation resulted in a negative value'
+      if mn<0: raise UnderflowError('Track time calculation resulted in a negative value')
       return _TrackTime((mn,sc,fr))
 
    @property

--- a/mktoc/test/test_cmdline.py
+++ b/mktoc/test/test_cmdline.py
@@ -10,7 +10,6 @@
 
 import unittest
 from mock import patch
-from contextlib import nested
 
 from mktoc.cmdline import *
 from mktoc.base import *
@@ -24,25 +23,23 @@ class TestCmdLine( unittest.TestCase):
 
    def testFileOpenUtf8(self):
       fh = self.cl._open_file( self._FILE_NAME,'wb','utf-8')
-      fh.write( u'\xf1' )
+      fh.write( '\xf1' )
       fh.close()
 
       fh = self.cl._open_file( self._FILE_NAME, encoding='utf-8')
       line = fh.read()
       fh.close()
-      self.assertTrue( line == u'\xf1' )
+      self.assertTrue( line == '\xf1' )
 
    def testParseError(self):
       """Verify that ParseError exception is caught and handled."""
-      with nested (
-            patch.object(CommandLine, '_run'),
-            patch.object(CommandLine, '_error_msg')
-            ) as (run_method, err_method):
+      with patch.object(CommandLine, '_run') as run_method, patch.object(
+              CommandLine, '_error_msg') as err_method:
          # throw a parseError
          run_method.side_effect = ParseError('message')
          self.cl.run()
-         self.assertEquals( err_method.call_count, 1 )
+         self.assertEqual( err_method.call_count, 1 )
          # the execption was passed to the err_method
-         self.assertEquals( err_method.call_args[0][0],
+         self.assertEqual( err_method.call_args[0][0],
                             run_method.side_effect )
 

--- a/mktoc/test/test_disc.py
+++ b/mktoc/test/test_disc.py
@@ -35,7 +35,7 @@ class TrackTimeTests(unittest.TestCase):
       """Time object must not be equal to each other."""
       a = _TrackTime('01:20:03')
       b = _TrackTime('01:02:03')
-      self.failIfEqual( a, b )
+      self.assertNotEqual( a, b )
 
    def testSubtractionOfSelf(self):
       """Time object must subtract correctly."""

--- a/mktoc/test/test_parser.py
+++ b/mktoc/test/test_parser.py
@@ -126,7 +126,7 @@ class CueParserFileTests(unittest.TestCase):
          toc_good = toc_fh.readlines()
       # compare data sets
       if toc != toc_good:
-         for num,(a,b) in enumerate(map(None,toc,toc_good)):
+         for num,(a,b) in enumerate(zip(toc,toc_good)):
             err_str = "strings do not match\n  %s:%d:%s\n  %s:%d:%s" % \
                         (self._cue_file,num,repr(a),
                          self._toc_file,num,repr(b))
@@ -138,7 +138,7 @@ class CueParserTests(unittest.TestCase):
    def testParseDisc_BadLine(self):
       cp = CueParser()
       file_ = ['BAD MATCH LINE']
-      self.assertRaisesRegexp(
+      self.assertRaisesRegex(
          ParseError, ".+: '%s'" % (file_[0]), cp.parse, file_ )
 
    def testParseTrack_BadLine(self):
@@ -146,7 +146,7 @@ class CueParserTests(unittest.TestCase):
       file_ = ['FILE "track1.wav" WAVE',
          'TRACK 01 AUDIO',
          'BAD MATCH LINE',]
-      self.assertRaisesRegexp(
+      self.assertRaisesRegex(
          ParseError, ".+: '%s'" % (file_[2],), cp.parse, file_)
 
    def testNoCueTracks(self):

--- a/mktoc/test/test_wav.py
+++ b/mktoc/test/test_wav.py
@@ -98,8 +98,8 @@ class WavFileCacheTests(unittest.TestCase):
    def testUnicodeFileNameMatch(self):
       """A unicode file should be matched correctly."""
       wc = WavFileCache()
-      wc._data = [u'/\xf1']
-      self.assertTrue( wc(u'\xf1'))
+      wc._data = ['/\xf1']
+      self.assertTrue( wc('\xf1'))
 
 
 ##############################################################################

--- a/mktoc/wav.py
+++ b/mktoc/wav.py
@@ -104,17 +104,17 @@ class WavFileCache(object):
       fn_pats.append( fn_pat )
       file_regex = re.compile( '|'.join(set(fn_pats)), re.IGNORECASE)
       # search all WAV files using pattern 'file_regex'
-      matchi = itr.imap( file_regex.search, self._get_cache() )
+      matchi = map( file_regex.search, self._get_cache() )
       # create tuple with input file and search results
-      matches = itr.izip( self._get_cache(), matchi )
-      matches = filter( op.itemgetter(1), matches )
+      matches = zip( self._get_cache(), matchi )
+      matches = list(filter( op.itemgetter(1), matches ))
       if len(matches) == 1:   # success if ONE match is found
          log.debug("--> FOUND '%s'" % matches[0][0])
          return matches[0][0]
       elif len(matches) == 0:
-         raise FileNotFoundError, file_ # zero or multiple matches is an error
+         raise FileNotFoundError(file_) # zero or multiple matches is an error
       else:
-         raise TooManyFilesMatchError, (file_, [m[0] for m in matches])
+         raise TooManyFilesMatchError(file_, [m[0] for m in matches])
 
    def _get_cache(self):
       """
@@ -136,13 +136,13 @@ class WavFileCache(object):
       for root, dirs, files in os.walk(self._src_dir):
          if fc > 1000: break     # only cache first n files
          fc += len(files)
-         f_tup = zip( [root]*len(files), files )
+         f_tup = list(zip( [root]*len(files), files ))
          wav_files = [os.path.join(r,f) for r,f in f_tup \
                            if self._WAV_REGEX.search(f)]
          self._data.extend( wav_files )
       self._is_init = True
       log.debug('-> Found %d files:' % len(self._data) )
-      map( lambda f: log.debug('--> %s' % f), self._data )
+      list(map( lambda f: log.debug('--> %s' % f), self._data ))
 
 
 ##############################################################################
@@ -216,7 +216,7 @@ class WavOffsetWriter(object):
       # set the dir name generation function, and create out_file list
       if not use_tmp_dir: outdir = self._get_new_name
       else              : outdir = self._get_tmp_name
-      out_files = map( outdir, files )
+      out_files = list(map( outdir, files ))
 
       # positive offset correction, insert silence in first track,
       # all other tracks insert end data of previous track
@@ -231,7 +231,7 @@ class WavOffsetWriter(object):
          # create a list of 'next' file names
          f2_list = files[1:] + [None]
 
-      map( offsetter_fnct, out_files, files, f2_list )
+      list(map( offsetter_fnct, out_files, files, f2_list ))
       # return a list of the new files names
       return out_files
 
@@ -296,7 +296,7 @@ class WavOffsetWriter(object):
 
       Parameter:
          files : List of WAV files to read."""
-      return sum(itr.imap( lambda f: wave.open(f).getnframes(), files))
+      return sum(map( lambda f: wave.open(f).getnframes(), files))
 
    def _get_tmp_name(self, f):
       """Generates a new name a location to write


### PR DESCRIPTION
I haven't tested if _everything_ is working as expected but all tests are OK.
This version is compatible with Python 3 only. No new dependencies have been added.

😉 

P.S. I've also landed a fix for #6 (forcing the encoding of new output files to be always `uft-8`).