### PR TITLE
Fix broken wave offset for Python 3 port

### DIFF
--- a/mktoc/wav.py
+++ b/mktoc/wav.py
@@ -341,12 +341,12 @@ class WavOffsetWriter(object):
          self._write_frames(wav_out, data ,bytes_p_samp)
          wav_in.close()
       else:    # insert silence if no previous file
-         self._write_frames(wav_out ,'\x00'*offset_bytes, bytes_p_samp)
+         self._write_frames(wav_out ,b'\x00'*offset_bytes, bytes_p_samp)
       # add original file data to output stream
       wav_in = wave.open( fn )
       samples = wav_in.getnframes() - self._offset
       while samples:
-         data = wav_in.readframes( min(samples,self._COPY_SIZE) )
+         data = wav_in.readframes( int(min(samples,self._COPY_SIZE)) )
          samples -= len(data) / bytes_p_samp
          self._write_frames(wav_out, data, bytes_p_samp)
       wav_in.close()


### PR DESCRIPTION
Contribued by @MerlijnWajer:
> I needed this patch for the offset writing to work. Please verify with `--offset-correction=6` (or another number, of course)

Fixes #10.

@cmcginty If you decide to merge this pull request could you also tag a new release?

Cheers,
Joe